### PR TITLE
Simplify table structure for address

### DIFF
--- a/backend/src/main/kotlin/com/beanpedia/model/Address.kt
+++ b/backend/src/main/kotlin/com/beanpedia/model/Address.kt
@@ -1,19 +1,6 @@
 package com.beanpedia.model
 
 import kotlinx.serialization.Serializable
-import org.jetbrains.exposed.sql.ReferenceOption
-import org.jetbrains.exposed.sql.Table
-
-object AddressEntities : Table() {
-    val id = integer("id").autoIncrement()
-    val address1 = varchar("address1", length = 255)
-    val address2 = varchar("address2", length = 255).nullable()
-    val address3 = varchar("address3", length = 255).nullable()
-    val city = varchar("city", length = 255)
-    val postalCode = varchar("postalCode", length = 255)
-    val countryId = reference("countryId", CountryEntities.id, ReferenceOption.RESTRICT, ReferenceOption.RESTRICT)
-    override val primaryKey = PrimaryKey(BeanEntities.id)
-}
 
 @Serializable
 data class Address(

--- a/backend/src/main/kotlin/com/beanpedia/model/Roastery.kt
+++ b/backend/src/main/kotlin/com/beanpedia/model/Roastery.kt
@@ -9,8 +9,16 @@ object RoasteryEntities : Table() {
     val externalId = uuid("externalId").uniqueIndex()
     val name = varchar("name", length = 255)
     val description = text("description").nullable()
-    val addressId = reference(
-        "addressId", AddressEntities.id, ReferenceOption.CASCADE, ReferenceOption.RESTRICT
+    val address1 = varchar("address1", length = 255).nullable()
+    val address2 = varchar("address2", length = 255).nullable()
+    val address3 = varchar("address3", length = 255).nullable()
+    val city = varchar("city", length = 255).nullable()
+    val postalCode = varchar("postalCode", length = 255).nullable()
+    val countryId = reference(
+        "countryId",
+        CountryEntities.id,
+        ReferenceOption.RESTRICT,
+        ReferenceOption.RESTRICT
     ).nullable()
     val phoneNumber = varchar("phoneNumber", length = 255).nullable()
     val website = varchar("website", length = 255).nullable()

--- a/backend/src/main/kotlin/com/beanpedia/service/DatabaseRoasteryService.kt
+++ b/backend/src/main/kotlin/com/beanpedia/service/DatabaseRoasteryService.kt
@@ -2,7 +2,6 @@ package com.beanpedia.service
 
 import com.beanpedia.exceptions.NotFoundException
 import com.beanpedia.model.Address
-import com.beanpedia.model.AddressEntities
 import com.beanpedia.model.CountryEntities
 import com.beanpedia.model.NewRoastery
 import com.beanpedia.model.Roastery
@@ -26,14 +25,21 @@ interface RoasteryService {
 }
 
 class DatabaseRoasteryService : RoasteryService {
+    private fun hasAddress(row: ResultRow): Boolean {
+        return row[RoasteryEntities.address1] != null &&
+            row[RoasteryEntities.city] != null &&
+            row[RoasteryEntities.postalCode] != null &&
+            row[RoasteryEntities.countryId] != null
+    }
+
     private fun toRoastery(row: ResultRow): Roastery {
-        val address = if (row[RoasteryEntities.addressId] != null) {
+        val address = if (hasAddress(row)) {
             Address(
-                address1 = row[AddressEntities.address1],
-                address2 = row[AddressEntities.address2],
-                address3 = row[AddressEntities.address3],
-                city = row[AddressEntities.city],
-                postalCode = row[AddressEntities.postalCode],
+                address1 = row[RoasteryEntities.address1]!!,
+                address2 = row[RoasteryEntities.address2],
+                address3 = row[RoasteryEntities.address3],
+                city = row[RoasteryEntities.city]!!,
+                postalCode = row[RoasteryEntities.postalCode]!!,
                 country = row[CountryEntities.alpha2Code]
             )
         } else null
@@ -53,13 +59,8 @@ class DatabaseRoasteryService : RoasteryService {
     override fun getAllRoasteries(): List<Roastery> =
         transaction {
             RoasteryEntities.join(
-                AddressEntities, JoinType.LEFT,
-                additionalConstraint = {
-                    AddressEntities.id eq RoasteryEntities.addressId
-                }
-            ).join(
                 CountryEntities, JoinType.LEFT,
-                additionalConstraint = { CountryEntities.id eq AddressEntities.countryId }
+                additionalConstraint = { CountryEntities.id eq RoasteryEntities.countryId }
             ).selectAll().map {
                 it
             }.map { toRoastery(it) }
@@ -67,36 +68,29 @@ class DatabaseRoasteryService : RoasteryService {
 
     override fun getRoastery(id: UUID): Roastery? = transaction {
         RoasteryEntities.join(
-            AddressEntities, JoinType.LEFT,
-            additionalConstraint = {
-                AddressEntities.id eq RoasteryEntities.addressId
-            }
-        ).join(
             CountryEntities, JoinType.LEFT,
-            additionalConstraint = { CountryEntities.id eq AddressEntities.countryId }
+            additionalConstraint = { CountryEntities.id eq RoasteryEntities.countryId }
         ).select {
             RoasteryEntities.externalId eq id
         }.mapNotNull { toRoastery(it) }.singleOrNull()
     }
 
     override fun createRoastery(roastery: NewRoastery): Roastery = transaction {
-        val address = if (roastery.address != null) {
-            AddressEntities.insert {
-                it[address1] = roastery.address.address1
-                it[address2] = roastery.address.address2
-                it[address3] = roastery.address.address3
-                it[city] = roastery.address.city
-                it[postalCode] = roastery.address.postalCode
-                it[countryId] = CountryEntities.slice(CountryEntities.id).select {
-                    CountryEntities.alpha2Code eq roastery.address.country
-                }.single()[CountryEntities.id]
-            } get AddressEntities.id
-        } else null
+        val countryIdFromDb = if (roastery.address?.country != null)
+            CountryEntities.slice(CountryEntities.id).select {
+                CountryEntities.alpha2Code eq roastery.address.country
+            }.single().get(CountryEntities.id) else null
+
         val roasteryId = RoasteryEntities.insert {
             it[externalId] = UUID.randomUUID()
             it[name] = roastery.name
             it[description] = roastery.description
-            it[addressId] = address
+            it[address1] = roastery.address?.address1
+            it[address2] = roastery.address?.address2
+            it[address3] = roastery.address?.address3
+            it[city] = roastery.address?.city
+            it[postalCode] = roastery.address?.postalCode
+            it[countryId] = countryIdFromDb
             it[phoneNumber] = roastery.phoneNumber
             it[website] = roastery.website
             it[facebook] = roastery.facebook
@@ -104,13 +98,8 @@ class DatabaseRoasteryService : RoasteryService {
             it[twitter] = roastery.twitter
         }.resultedValues!!.map { it[RoasteryEntities.externalId] }.single()
         RoasteryEntities.join(
-            AddressEntities, JoinType.LEFT,
-            additionalConstraint = {
-                AddressEntities.id eq RoasteryEntities.addressId
-            }
-        ).join(
             CountryEntities, JoinType.LEFT,
-            additionalConstraint = { CountryEntities.id eq AddressEntities.countryId }
+            additionalConstraint = { CountryEntities.id eq RoasteryEntities.countryId }
         ).select {
             RoasteryEntities.externalId eq roasteryId
         }.map { toRoastery(it) }.single()
@@ -125,54 +114,28 @@ class DatabaseRoasteryService : RoasteryService {
         }
     }
 
-    @Suppress("LongMethod")
     override fun updateRoastery(updatedRoastery: NewRoastery, id: UUID): Roastery = transaction {
-        val roastery = RoasteryEntities.join(
-            AddressEntities, JoinType.LEFT,
-            additionalConstraint = {
-                AddressEntities.id eq RoasteryEntities.addressId
-            }
-        ).join(
+        RoasteryEntities.join(
             CountryEntities, JoinType.LEFT,
-            additionalConstraint = { CountryEntities.id eq AddressEntities.countryId }
+            additionalConstraint = { CountryEntities.id eq RoasteryEntities.countryId }
         ).select {
             RoasteryEntities.externalId eq id
         }.singleOrNull() ?: throw NotFoundException()
 
-        var existingAddressId = roastery[RoasteryEntities.addressId]
-        if (existingAddressId != null) {
-            if (updatedRoastery.address == null) {
-                AddressEntities.deleteWhere { AddressEntities.id eq existingAddressId!! }
-                existingAddressId = null
-            } else {
-                AddressEntities.update({ AddressEntities.id eq existingAddressId!! }) {
-                    it[address1] = updatedRoastery.address.address1
-                    it[address2] = updatedRoastery.address.address2
-                    it[address3] = updatedRoastery.address.address3
-                    it[city] = updatedRoastery.address.city
-                    it[postalCode] = updatedRoastery.address.city
-                    it[countryId] = CountryEntities.slice(CountryEntities.id).select {
-                        CountryEntities.alpha2Code eq updatedRoastery.address.country
-                    }.single()[CountryEntities.id]
-                }
-            }
-        } else if (updatedRoastery.address != null) {
-            existingAddressId = AddressEntities.insert {
-                it[address1] = updatedRoastery.address.address1
-                it[address2] = updatedRoastery.address.address2
-                it[address3] = updatedRoastery.address.address3
-                it[city] = updatedRoastery.address.city
-                it[postalCode] = updatedRoastery.address.postalCode
-                it[countryId] = CountryEntities.slice(CountryEntities.id).select {
-                    CountryEntities.alpha2Code eq updatedRoastery.address.country
-                }.single()[CountryEntities.id]
-            } get AddressEntities.id
-        }
+        val countryIdFromDb = if (updatedRoastery.address?.country != null)
+            CountryEntities.slice(CountryEntities.id).select {
+                CountryEntities.alpha2Code eq updatedRoastery.address.country
+            }.single().get(CountryEntities.id) else null
 
         RoasteryEntities.update({ RoasteryEntities.externalId eq id }) {
             it[name] = updatedRoastery.name
             it[description] = updatedRoastery.description
-            it[addressId] = existingAddressId
+            it[address1] = updatedRoastery.address?.address1
+            it[address2] = updatedRoastery.address?.address2
+            it[address3] = updatedRoastery.address?.address3
+            it[city] = updatedRoastery.address?.city
+            it[postalCode] = updatedRoastery.address?.postalCode
+            it[countryId] = countryIdFromDb
             it[phoneNumber] = updatedRoastery.phoneNumber
             it[website] = updatedRoastery.website
             it[facebook] = updatedRoastery.facebook
@@ -180,13 +143,8 @@ class DatabaseRoasteryService : RoasteryService {
             it[twitter] = updatedRoastery.twitter
         }
         RoasteryEntities.join(
-            AddressEntities, JoinType.LEFT,
-            additionalConstraint = {
-                AddressEntities.id eq RoasteryEntities.addressId
-            }
-        ).join(
             CountryEntities, JoinType.LEFT,
-            additionalConstraint = { CountryEntities.id eq AddressEntities.countryId }
+            additionalConstraint = { CountryEntities.id eq RoasteryEntities.countryId }
         ).select {
             RoasteryEntities.externalId eq id
         }.map { toRoastery(it) }.single()

--- a/backend/src/main/kotlin/db/migration/V1__initial_migration.kt
+++ b/backend/src/main/kotlin/db/migration/V1__initial_migration.kt
@@ -1,6 +1,5 @@
 package db.migration
 
-import com.beanpedia.model.AddressEntities
 import com.beanpedia.model.BeanEntities
 import com.beanpedia.model.BeanOriginEntities
 import com.beanpedia.model.CountryEntities
@@ -271,8 +270,7 @@ class V1__initial_migration : BaseJavaMigration() {
                 CountryEntities,
                 BeanOriginEntities,
                 BeanEntities,
-                RoasteryEntities,
-                AddressEntities
+                RoasteryEntities
             )
             CountryEntities.batchInsert(alpha2Codes) {
                 countryCode ->


### PR DESCRIPTION
In order to avoid multiple joins when querying a roastery the address is moved into the roastery table.